### PR TITLE
README.md: Fixed heading rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ For an *end-entity certificate*, the **Signing-Key will be the one of our CA**, 
 the **Key-Grip will correspond to the entity public key**. Those value should
 not match.
 
-## Self-signed CA certificate
+## Self-signed CA certificate
 
 This section details the command to create the CA self-signed certificate.
 


### PR DESCRIPTION
Corrected a whitespace issue that prevented the "Self-signed CA certificate" section heading from rendering properly.